### PR TITLE
Replacing Gitter link with linkt to Discord

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,7 @@
           <h2 class="footer-title">Community</h2>
           <a rel="noopener noreferrer" href="https://medium.com/@raiden_trust" target="_blank">Medium</a>
           <a rel="noopener noreferrer" href="https://twitter.com/raiden_trust" target="_blank">Twitter</a>
-          <a rel="noopener noreferrer" href="https://gitter.im/raiden-network/raiden" target="_blank">Dev Chat</a>
+          <a rel="noopener noreferrer" href="https://discord.com/invite/nSQDQBq5FC" target="_blank">Dev Chat</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Since we have moved the community from Gitter to Discord any references to Gitter needs to be updated accordingly.